### PR TITLE
Stop coveralls from being picked up as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,8 @@ macros = []
 install_requires = ["scipy", "numpy", "natsort", "cython", "pysam"]
 
 
-try:
-    os.getenv("TRAVIS")
+if os.getenv("TRAVIS"):
     install_requires.append("coveralls")
-except:
-    pass
 
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
* `os.getenv("TRAVIS")` never raises any errors, defaults to 'None'
* but 'None' is false-ish, can be used in an `if` statement